### PR TITLE
Closes #22 - add oauth to api

### DIFF
--- a/API/API.csproj
+++ b/API/API.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="AutoMapper" Version="10.1.1" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.21" />
     <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="5.0.5" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.2" />

--- a/API/Controllers/ArticlesController.cs
+++ b/API/Controllers/ArticlesController.cs
@@ -2,6 +2,7 @@
 using AutoMapper;
 using Data;
 using Data.Models;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.JsonPatch;
 using Microsoft.AspNetCore.Mvc;
@@ -13,6 +14,7 @@ using System.Threading.Tasks;
 namespace API.Controllers
 {
     [ApiController]
+    [Authorize]
     [Route("[controller]")]
     public class ArticlesController : Controller
     {

--- a/API/Controllers/CharactersController.cs
+++ b/API/Controllers/CharactersController.cs
@@ -2,6 +2,7 @@
 using AutoMapper;
 using Data;
 using Data.Models;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using System;
@@ -12,6 +13,7 @@ using System.Threading.Tasks;
 namespace API.Controllers
 {
     [ApiController]
+    [Authorize]
     [Route("[controller]")]
     public class CharactersController : Controller
     {

--- a/API/Controllers/LeadsController.cs
+++ b/API/Controllers/LeadsController.cs
@@ -1,4 +1,5 @@
 ﻿using API.DTOs;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using System;
@@ -9,6 +10,7 @@ using System.Threading.Tasks;
 namespace API.Controllers
 {
     [ApiController]
+    [Authorize]
     [Route("[controller]")]
     public class LeadsController : Controller
     {

--- a/API/Controllers/MediaController.cs
+++ b/API/Controllers/MediaController.cs
@@ -2,6 +2,7 @@
 using Data;
 using Data.Constants;
 using Data.Models;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using System;
@@ -14,6 +15,7 @@ using System.Threading.Tasks;
 namespace API.Controllers
 {
     [ApiController]
+    [Authorize]
     [Route("[controller]")]
     public class MediaController : Controller
     {

--- a/API/Controllers/UsersController.cs
+++ b/API/Controllers/UsersController.cs
@@ -2,6 +2,7 @@
 using AutoMapper;
 using Data;
 using Data.Models;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using System;
@@ -12,6 +13,7 @@ using System.Threading.Tasks;
 namespace API.Controllers
 {
     [ApiController]
+    [Authorize]
     [Route("[controller]")]
     public class UsersController : Controller
     {

--- a/API/appsettings.json
+++ b/API/appsettings.json
@@ -1,4 +1,7 @@
 {
+  "OAuth2": {
+    "Base_Url": "http://localhost:9011"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/CMS/CMS.csproj
+++ b/CMS/CMS.csproj
@@ -10,7 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="IdentityServer4.AspNetIdentity" Version="4.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="3.1.14" />
+    <PackageReference Include="ProxyKit" Version="2.3.4" />
   </ItemGroup>
 
   <ItemGroup>
@@ -22,6 +24,9 @@
 
   <ItemGroup>
     <None Update="ClientApp\src\api\articles.ts">
+      <SubType>Code</SubType>
+    </None>
+    <None Update="ClientApp\src\hooks\useAuth.ts">
       <SubType>Code</SubType>
     </None>
     <None Update="ClientApp\src\api\search.ts">
@@ -64,6 +69,9 @@
       <SubType>Code</SubType>
     </None>
     <None Update="ClientApp\src\components\Page.tsx">
+      <SubType>Code</SubType>
+    </None>
+    <None Update="ClientApp\src\components\AuthRoute.tsx">
       <SubType>Code</SubType>
     </None>
     <None Update="ClientApp\src\pages\ArticleList\index.ts">

--- a/CMS/ClientApp/package-lock.json
+++ b/CMS/ClientApp/package-lock.json
@@ -3094,6 +3094,11 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/cookie": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
+      "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow=="
+    },
     "@types/date-fns": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/@types/date-fns/-/date-fns-2.6.0.tgz",
@@ -3143,7 +3148,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
       "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
-      "dev": true,
       "requires": {
         "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0"
@@ -15915,6 +15919,16 @@
         }
       }
     },
+    "react-cookie": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/react-cookie/-/react-cookie-4.1.1.tgz",
+      "integrity": "sha512-ffn7Y7G4bXiFbnE+dKhHhbP+b8I34mH9jqnm8Llhj89zF4nPxPutxHT1suUqMeCEhLDBI7InYwf1tpaSoK5w8A==",
+      "requires": {
+        "@types/hoist-non-react-statics": "^3.0.1",
+        "hoist-non-react-statics": "^3.0.0",
+        "universal-cookie": "^4.0.0"
+      }
+    },
     "react-dev-utils": {
       "version": "11.0.4",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-11.0.4.tgz",
@@ -19554,6 +19568,15 @@
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
       "requires": {
         "crypto-random-string": "^1.0.0"
+      }
+    },
+    "universal-cookie": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-4.0.4.tgz",
+      "integrity": "sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==",
+      "requires": {
+        "@types/cookie": "^0.3.3",
+        "cookie": "^0.4.0"
       }
     },
     "universalify": {

--- a/CMS/ClientApp/package.json
+++ b/CMS/ClientApp/package.json
@@ -27,6 +27,7 @@
     "merge": "^2.1.1",
     "popper.js": "^1.16.0",
     "react": "^17.0.0",
+    "react-cookie": "^4.1.1",
     "react-dom": "^17.0.0",
     "react-helmet": "^6.1.0",
     "react-infinite-scroll-component": "^6.1.0",

--- a/CMS/ClientApp/src/App.tsx
+++ b/CMS/ClientApp/src/App.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Route, Switch, useRouteMatch } from 'react-router-dom';
+import { AuthRoute } from './components';
 import { ArticleCreate, ArticleEdit, ArticleList, CharacterCreate, CharacterEdit, CharacterList, Help, Home, Media, UserCreate, UserEdit, UserList } from './pages';
 
 export default function App() {
@@ -9,47 +10,47 @@ export default function App() {
         <>
             <Switch>
 
-                <Route exact path='/'>
+                <AuthRoute exact path='/'>
                     <Home />
-                </Route>
+                </AuthRoute>
 
-                <Route exact path='/articles'>
+                <AuthRoute exact path='/articles'>
                     <ArticleList />
-                </Route>
-                <Route exact path='/articles/new'>
+                </AuthRoute>
+                <AuthRoute exact path='/articles/new'>
                     <ArticleCreate />
-                </Route>
-                <Route
+                </AuthRoute>
+                <AuthRoute
                     exact path='/articles/:articleId(\d+)'
                     render={({ match }) => <ArticleEdit articleId={match.params['articleId']} />}
                 />
 
-                <Route exact path='/characters'>
+                <AuthRoute exact path='/characters'>
                     <CharacterList />
-                </Route>
-                <Route exact path='/characters/new'>
+                </AuthRoute>
+                <AuthRoute exact path='/characters/new'>
                     <CharacterCreate />
-                </Route>
-                <Route
+                </AuthRoute>
+                <AuthRoute
                     exact path='/characters/:characterId(\d+)'
                     render={({ match }) => <CharacterEdit characterId={match.params['characterId']} />}
                 />
 
-                <Route exact path='/help'>
+                <AuthRoute exact path='/help'>
                     <Help />
-                </Route>
+                </AuthRoute>
 
-                <Route exact path='/media'>
+                <AuthRoute exact path='/media'>
                     <Media />
-                </Route>
+                </AuthRoute>
 
-                <Route exact path='/users'>
+                <AuthRoute exact path='/users'>
                     <UserList />
-                </Route>
-                <Route exact path='/users/new'>
+                </AuthRoute>
+                <AuthRoute exact path='/users/new'>
                     <UserCreate />
-                </Route>
-                <Route
+                </AuthRoute>
+                <AuthRoute
                     exact path='/users/:userId(\d+)'
                     render={({ match }) => <UserEdit userId={match.params['userId']} />}
                 />

--- a/CMS/ClientApp/src/api/articles.ts
+++ b/CMS/ClientApp/src/api/articles.ts
@@ -28,7 +28,7 @@ export function useArticles(search: string) {
             query: search,
             offset: pageParam?.toString() ?? 0,
         });
-        const endpoint = `${process.env.REACT_APP_API_URL}/articles?`;
+        const endpoint = `${process.env.REACT_APP_API_URL}/articles`;
         const response = await fetch(endpoint + '?' + parameters);
         return await response.json() as SearchResults<ArticleSummary>;
     }

--- a/CMS/ClientApp/src/api/characters.ts
+++ b/CMS/ClientApp/src/api/characters.ts
@@ -32,7 +32,7 @@ export function useCharacters(search: string) {
             query: search,
             offset: pageParam?.toString() ?? 0,
         });
-        const endpoint = `${process.env.REACT_APP_API_URL}/characters?`;
+        const endpoint = `${process.env.REACT_APP_API_URL}/characters`;
         const response = await fetch(endpoint + '?' + parameters);
         return await response.json() as SearchResults<CharacterSummary>;
     }

--- a/CMS/ClientApp/src/api/media.ts
+++ b/CMS/ClientApp/src/api/media.ts
@@ -21,7 +21,7 @@ export function useMedia(search: string) {
             query: search,
             offset: pageParam?.toString() ?? 0,
         });
-        const endpoint = `${process.env.REACT_APP_API_URL}/media?`;
+        const endpoint = `${process.env.REACT_APP_API_URL}/media`;
         const response = await fetch(endpoint + '?' + parameters);
         return await response.json() as SearchResults<MediaSummary>;
     }

--- a/CMS/ClientApp/src/api/users.ts
+++ b/CMS/ClientApp/src/api/users.ts
@@ -27,7 +27,7 @@ export function useUsers(search: string) {
             query: search,
             offset: pageParam?.toString() ?? 0,
         });
-        const endpoint = `${process.env.REACT_APP_API_URL}/users?`;
+        const endpoint = `${process.env.REACT_APP_API_URL}/users`;
         const response = await fetch(endpoint + '?' + parameters);
         return await response.json() as SearchResults<UserSummary>;
     }

--- a/CMS/ClientApp/src/components/AuthRoute.tsx
+++ b/CMS/ClientApp/src/components/AuthRoute.tsx
@@ -1,0 +1,33 @@
+﻿import { ReactElement } from 'react';
+import { Route, RouteComponentProps } from 'react-router-dom';
+import { Redirect, StaticContext } from 'react-router';
+import { useAuth } from '../hooks/useAuth';
+
+
+interface IProps {
+    exact: boolean,
+    path: string,
+    render?: ({ match }: RouteComponentProps<any, StaticContext, any>) => JSX.Element,
+    children?: ReactElement
+}
+
+export default function AuthRoute({
+    exact,
+    path,
+    render,
+    children
+}: IProps) {
+
+    var user = useAuth();
+
+    if (!user || !user.email) {
+        // This needs replaced later but for now just use the backend to force a refresh.
+        window.location.reload();
+    }
+
+    return (
+        <Route exact={exact} path={path} render={render}>
+            {children}
+        </Route>
+    );
+}

--- a/CMS/ClientApp/src/components/index.ts
+++ b/CMS/ClientApp/src/components/index.ts
@@ -1,4 +1,5 @@
-﻿export { default as DrawerItem } from './DrawerItem';
+﻿export { default as AuthRoute } from './AuthRoute';
+export { default as DrawerItem } from './DrawerItem';
 export { default as Editor } from './Editor';
 export { default as ImageGrid } from './ImageGrid';
 export { default as NavDrawer } from './NavDrawer';

--- a/CMS/ClientApp/src/hooks/useAuth.ts
+++ b/CMS/ClientApp/src/hooks/useAuth.ts
@@ -1,0 +1,14 @@
+﻿import { useCookies } from 'react-cookie';
+
+export interface CurrentUser {
+    email: string,
+    name: string,
+    scope: string[],
+    username: string,
+}
+
+export function useAuth() {
+    var [cookies] = useCookies(['jwt']);
+    var jwtCookie = cookies.jwt as CurrentUser;
+    return jwtCookie;
+}

--- a/CMS/Properties/launchSettings.json
+++ b/CMS/Properties/launchSettings.json
@@ -13,7 +13,7 @@
       "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
-        "REACT_APP_API_URL": "https://localhost:44300"
+        "REACT_APP_API_URL": "https://localhost:44381/api"
       }
     },
     "CMS": {

--- a/CMS/Startup.cs
+++ b/CMS/Startup.cs
@@ -1,3 +1,7 @@
+using IdentityModel.Client;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.HttpsPolicy;
@@ -6,6 +10,14 @@ using Microsoft.AspNetCore.SpaServices.ReactDevelopmentServer;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.IdentityModel.Logging;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.IdentityModel.Tokens;
+using Microsoft.Net.Http.Headers;
+using ProxyKit;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
 
 namespace CMS
 {
@@ -21,6 +33,8 @@ namespace CMS
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddProxy();
+
             services.AddControllersWithViews();
 
             // In production, the React files will be served from this directory
@@ -28,6 +42,36 @@ namespace CMS
             {
                 configuration.RootPath = "ClientApp/build";
             });
+
+            services.AddAuthentication(options =>
+            {
+                options.DefaultScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+                options.DefaultChallengeScheme = OpenIdConnectDefaults.AuthenticationScheme;
+            })
+                .AddCookie(CookieAuthenticationDefaults.AuthenticationScheme)
+                .AddOpenIdConnect(OpenIdConnectDefaults.AuthenticationScheme, options =>
+                {
+                    options.Authority = Configuration["OIDC:Authority"];
+                    options.ClientId = Configuration["OIDC:ClientId"];
+                    options.ClientSecret = Configuration["OIDC:ClientSecret"];
+                    options.GetClaimsFromUserInfoEndpoint = true;
+#if DEBUG
+                    options.RequireHttpsMetadata = false;
+#endif
+                    options.ResponseType = OpenIdConnectResponseType.Code;
+                    options.SaveTokens = true;
+                    options.UsePkce = false;
+
+                    options.Events = new OpenIdConnectEvents
+                    {
+                        OnUserInformationReceived = (UserInformationReceivedContext context) =>
+                        {
+                            var jwt = JsonSerializer.Serialize(context.User.RootElement);
+                            context.HttpContext.Response.Cookies.Append("jwt", jwt);
+                            return Task.CompletedTask;
+                        }
+                    };
+                });
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -47,6 +91,29 @@ namespace CMS
             app.UseSpaStaticFiles();
 
             app.UseRouting();
+
+            app.UseAuthentication();
+
+            app.Use(async (context, next) =>
+            {
+                if (!context.User.Identity.IsAuthenticated)
+                {
+                    await context.ChallengeAsync();
+                    return;
+                }
+                await next();
+            });
+
+            app.Map("/api", api =>
+            {
+                api.RunProxy(async context =>
+                {
+                    var forwardContext = context.ForwardTo(Configuration["APIBaseUri"]);
+                    var token = await context.GetTokenAsync("access_token");
+                    forwardContext.UpstreamRequest.SetBearerToken(token);
+                    return await forwardContext.Send();
+                });
+            });
 
             app.UseEndpoints(endpoints =>
             {

--- a/CMS/appsettings.json
+++ b/CMS/appsettings.json
@@ -6,5 +6,12 @@
       "Microsoft.Hosting.Lifetime": "Information"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+
+  "APIBaseUri": "https://localhost:44300",
+  "OIDC": {
+    "Authority": "http://localhost:9011",
+    "ClientId": "dc487e3d-1a6a-49b6-a957-150dd821bbd8",
+    "ClientSecret": "CgsVzLtFtQ4Bj6GDw2dyVwuS25s0vVYF5mdsfdf7nBw"
+  }
 }

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ After cloning the repo, follow these steps to start the project:
 
  1. Create a leggo_news database.
  2. Create a leggo_news user for the database table.  The password should be "password".
- 3. Run the software for the first time.
+ 3. Set up an OAuth server.  FusionAuth is recommended.  Configure with environment variables.
+ 4. Run the software for the first time.
 
 Happy coding!
 


### PR DESCRIPTION
I set up an identity server locally.  Then I added OAuth to the API project and configured Swagger to work with it.  Doing this broke the CMS, so I added OAuth support to it as well.  For security of the client secrets, the CMS calls to the API are routed through a proxy on the backend.